### PR TITLE
Better fix of the saturation problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "file_backed"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_backed"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 documentation = "https://docs.rs/file_backed"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
         persisted_key = item1.key(); // Remember the key
 
         // Persist (e.g., hard-links to persist_dir)
-        item1.spawn_persist(&tracked_persist).await?;
+        item1.spawn_persist(&tracked_persist).await.await?;
         // Optional: store.sync(tracked_persist).await?; // For durability
 
         println!("Persisted item with key: {}", persisted_key);

--- a/examples/persistence.rs
+++ b/examples/persistence.rs
@@ -35,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         persisted_key = item1.key(); // Remember the key
 
         // Persist (e.g., hard-links to persist_dir)
-        item1.spawn_persist(&tracked_persist).await?;
+        item1.spawn_persist(&tracked_persist).await.await?;
         // Optional: store.sync(tracked_persist).await?; // For durability
 
         println!("Persisted item with key: {}", persisted_key);

--- a/examples/persistence.rs
+++ b/examples/persistence.rs
@@ -3,14 +3,13 @@
 use std::sync::Arc;
 
 use tempfile::tempdir;
-use tokio::runtime;
+use tokio::runtime::Handle;
 
 use file_backed::fbstore::{BinCodec, FBStore, PreparedPath};
 use file_backed::{BackingStore, FBPool};
 
-fn main() -> anyhow::Result<()> {
-    let runtime = runtime::Builder::new_multi_thread().build()?;
-
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     // 1. Setup distinct paths for cache and persistent storage
     let cache_dir = tempdir()?;
     let persist_dir = tempdir()?;
@@ -23,54 +22,56 @@ fn main() -> anyhow::Result<()> {
 
     // --- Scope 1: Insert and Persist ---
     {
-        let prepared_cache_path = PreparedPath::blocking_new(cache_store_path.clone(), vec![]);
-        let prepared_persist_path = PreparedPath::blocking_new(persist_store_path.clone(), vec![]);
+        let prepared_cache_path = PreparedPath::new(cache_store_path.clone(), vec![]).await;
+        let prepared_persist_path = PreparedPath::new(persist_store_path.clone(), vec![]).await;
 
         let fb_store = FBStore::new(BinCodec, prepared_cache_path);
-        let store = Arc::new(BackingStore::new(fb_store, runtime.handle().clone()));
+        let store = Arc::new(BackingStore::new(fb_store, Handle::current()));
         let pool: Arc<FBPool<String, _>> = Arc::new(FBPool::new(store.clone(), 1));
 
         // Track persistent path & insert
-        let tracked_persist = Arc::new(store.blocking_track_path(prepared_persist_path));
+        let tracked_persist = Arc::new(store.track_path(prepared_persist_path).await?);
         let item1 = pool.insert("Persisted Data".to_string());
         persisted_key = item1.key(); // Remember the key
 
         // Persist (e.g., hard-links to persist_dir)
-        item1.blocking_persist(&tracked_persist);
+        item1.spawn_persist(&tracked_persist).await?;
         // Optional: store.sync(tracked_persist).await?; // For durability
 
         println!("Persisted item with key: {}", persisted_key);
-
-        runtime.block_on(store.finished());
+        // item1, pool, store dropped here; cache file might be deleted later
+        store.finished().await;
     }
 
     // --- Scope 2: Simulate Restart, Register, and Load ---
     {
         // Re-create store/pool pointing to the same paths
-        let prepared_cache_path = PreparedPath::blocking_new(cache_store_path, vec![]);
-        let prepared_persist_path = PreparedPath::blocking_new(persist_store_path, vec![]); // Must exist
+        let prepared_cache_path = PreparedPath::new(cache_store_path, vec![]).await;
+        let prepared_persist_path = PreparedPath::new(persist_store_path, vec![]).await; // Must exist
 
         let fb_store = FBStore::new(BinCodec, prepared_cache_path);
-        let store = Arc::new(BackingStore::new(fb_store, runtime.handle().clone()));
+        let store = Arc::new(BackingStore::new(fb_store, Handle::current()));
         let pool: Arc<FBPool<String, _>> = Arc::new(FBPool::new(store.clone(), 1));
 
         // Re-track persistent path
-        let tracked_persist = Arc::new(store.blocking_track_path(prepared_persist_path));
+        let tracked_persist = Arc::new(store.track_path(prepared_persist_path).await?);
 
         // Register the previously persisted item by its key
         let registered_item = pool
-            .blocking_register(&tracked_persist, persisted_key)
+            .register(&tracked_persist, persisted_key)
+            .await
             .expect("Failed to register item");
 
         println!("Registered item with key: {}", persisted_key);
 
         // Load the registered item (loads from persist_dir link into cache_dir)
-        let guard = registered_item.blocking_load();
+        let guard = registered_item.load().await;
         println!("Loaded registered data: {}", *guard);
         assert_eq!(*guard, "Persisted Data");
         drop(guard);
 
-        runtime.block_on(store.finished());
+        // registered_item, pool, store dropped here
+        store.finished().await;
     }
 
     Ok(())

--- a/examples/simple_usage.rs
+++ b/examples/simple_usage.rs
@@ -3,19 +3,18 @@
 use std::sync::Arc;
 
 use tempfile::tempdir;
-use tokio::runtime;
+use tokio::runtime::Handle;
 
 use file_backed::fbstore::{BinCodec, FBStore, PreparedPath};
 use file_backed::{BackingStore, FBPool};
 
-fn main() -> anyhow::Result<()> {
-    let runtime = runtime::Builder::new_multi_thread().build()?;
-
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     // 1. Setup store and pool
     let temp_dir = tempdir()?;
-    let prepared_path = PreparedPath::blocking_new(temp_dir.path().to_path_buf(), vec![]);
+    let prepared_path = PreparedPath::new(temp_dir.path().to_path_buf(), vec![]).await;
     let fb_store = FBStore::new(BinCodec, prepared_path); // Uses BinCodec for String
-    let store = Arc::new(BackingStore::new(fb_store, runtime.handle().clone()));
+    let store = Arc::new(BackingStore::new(fb_store, Handle::current()));
     let pool: Arc<FBPool<String, _>> = Arc::new(FBPool::new(store.clone(), 2)); // Cache size 2
 
     // 2. Insert items
@@ -28,15 +27,14 @@ fn main() -> anyhow::Result<()> {
     }
 
     // 3. Load an item (might load from disk if evicted)
-    let guard = items[0].blocking_load(); // Load "Hello". Now "World" will be evicted.
+    let guard = items[0].load().await; // Load "Hello". Now "World" will be evicted.
     println!("Loaded: {}", *guard);
     assert_eq!(*guard, "Hello");
     drop(guard);
 
     // 4. Arcs automatically cleaned up when dropped
     drop(items);
-
-    runtime.block_on(store.finished());
+    store.finished().await; // Wait for background tasks to finish (e.g., file deletions)
 
     Ok(())
 }

--- a/src/entries.rs
+++ b/src/entries.rs
@@ -245,9 +245,33 @@ impl<T: Send + Sync + 'static, B: Strategy<T>> FullEntry<T, B> {
         RwLockWriteGuard::map(guard, |b| b.memory.as_mut().unwrap())
     }
 
+    pub(super) fn spawn_write_now(&self, store: &Arc<BackingStore<B>>) -> JoinHandle<()> {
+        let backing = Arc::clone(&self.backing);
+        let meta = Arc::clone(&self.meta);
+        let store_clone = Arc::clone(store);
+        store.spawn_blocking(move || {
+            let guard = backing.blocking_read();
+            guard.blocking_store(&store_clone, *meta.key.try_read().unwrap());
+        })
+    }
+
     pub(super) fn blocking_write_now(&self, store: &Arc<BackingStore<B>>) {
         let read_guard = self.backing.blocking_read();
         read_guard.blocking_store(store, self.key());
+    }
+
+    pub(super) fn spawn_persist(
+        &self,
+        store: &Arc<BackingStore<B>>,
+        path: &Arc<TrackedPath<B::PersistPath>>,
+    ) -> JoinHandle<()> {
+        let backing = Arc::clone(&self.backing);
+        let meta = Arc::clone(&self.meta);
+        let store_clone = Arc::clone(store);
+        let path = Arc::clone(path);
+        store.spawn_blocking(move || {
+            blocking_persist(&backing, &store_clone, &meta, &path);
+        })
     }
 
     pub(super) fn blocking_persist(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,10 +333,10 @@ impl<T: Send + Sync + 'static, B: Strategy<T>> Fb<T, B> {
     /// Spawns a background task to immediately write the data to the backing store's
     /// temporary location if it isn't already there.
     ///
-    /// Returns a `JoinHandle` that completes when the write operation finishes.
-    /// This is useful for initiating writes without blocking.
-    pub fn spawn_write_now(&self) -> JoinHandle<()> {
-        self.entry.spawn_write_now(&self.inner.pool.store)
+    /// Acquires the read guard and then returns a `JoinHandle` that completes when the write
+    /// operation finishes.
+    pub async fn spawn_write_now(&self) -> JoinHandle<()> {
+        self.entry.spawn_write_now(&self.inner.pool.store).await
     }
 
     /// Performs a blocking write of the data to the backing store's temporary location
@@ -352,9 +352,11 @@ impl<T: Send + Sync + 'static, B: Strategy<T>> Fb<T, B> {
     /// is currently only in memory, it ensures it's written to the temporary
     /// location first before attempting persistence.
     /// If the data is already in the persistent location, this is a no-op.
-    /// Returns a `JoinHandle` that completes when the persistence operation finishes.
-    pub fn spawn_persist(&self, path: &Arc<TrackedPath<B::PersistPath>>) -> JoinHandle<()> {
-        self.entry.spawn_persist(&self.inner.pool.store, path)
+    ///
+    /// Acquires the read guard and then returns a `JoinHandle` that completes when the persistence
+    /// operation finishes.
+    pub async fn spawn_persist(&self, path: &Arc<TrackedPath<B::PersistPath>>) -> JoinHandle<()> {
+        self.entry.spawn_persist(&self.inner.pool.store, path).await
     }
 
     /// Performs a blocking persistence of the data to the specified `TrackedPath`.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -376,16 +376,13 @@ async fn test_write_now_triggers_store_drop_triggers_delete() {
         content: "write_now_delete".to_string(),
     };
 
-    let item1 = setup.pool.insert(data1.clone());
-    let key1 = item1.key();
+    let arc1 = setup.pool.insert(data1.clone());
+    let key1 = arc1.key();
     assert!(!setup.store_impl.get_temp_keys().contains(&key1)); // Not written yet
 
     // --- Action: Explicit Write ---
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item1.blocking_write_now();
-        item1
-    });
-    let item1 = write_handle.await.unwrap();
+    let write_handle = arc1.spawn_write_now(); // Use async version
+    write_handle.await.unwrap();
     // --- Verification ---
     // store: 1 (Written explicitly)
     // load: 0
@@ -395,17 +392,14 @@ async fn test_write_now_triggers_store_drop_triggers_delete() {
     assert!(setup.store_impl.get_temp_keys().contains(&key1));
 
     // --- Action: Write again (should be no-op for store) ---
-    let write_handle2 = tokio::task::spawn_blocking(move || {
-        item1.blocking_write_now();
-        item1
-    });
-    let item1 = write_handle2.await.unwrap();
+    let write_handle2 = arc1.spawn_write_now();
+    write_handle2.await.unwrap();
     // --- Verification ---
     // store: 1 (Already written, no new store call)
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
 
     // --- Action: Drop Arc ---
-    drop(item1);
+    drop(arc1);
     wait_for_store(&setup.backing_store).await;
     // --- Verification ---
     // delete: 1 (Item was written to temp store)
@@ -492,8 +486,8 @@ async fn test_persist_triggers_store_if_not_written_noop_if_done() {
     let persist_path = test_path_b();
 
     // --- Action: Insert ---
-    let item = setup.pool.insert(data.clone());
-    let key = item.key();
+    let arc = setup.pool.insert(data.clone());
+    let key = arc.key();
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 0);
     assert_eq!(setup.calls.persist.load(Ordering::SeqCst), 0);
     assert!(!setup.store_impl.get_temp_keys().contains(&key));
@@ -510,14 +504,8 @@ async fn test_persist_triggers_store_if_not_written_noop_if_done() {
     assert!(!tracked_path.all_keys().contains(&key));
 
     // --- Action: Persist (first time, not written yet, not persisted yet) ---
-    let persist_handle = tokio::task::spawn_blocking({
-        let tracked_path = tracked_path.clone();
-        move || {
-            item.blocking_persist(&tracked_path);
-            item
-        }
-    });
-    let item = persist_handle.await.unwrap();
+    let persist_handle = arc.spawn_persist(&tracked_path);
+    persist_handle.await.unwrap();
     // --- Verification ---
     // store: 1 (Writes to temp first)
     // persist: 1 (BackingStoreT::persist called)
@@ -538,14 +526,8 @@ async fn test_persist_triggers_store_if_not_written_noop_if_done() {
     // checks the TrackedPath passed in. Let's assume it checks the path.
 
     // --- Action: Persist Again (already written to temp, *and* already persisted at path) ---
-    let persist_handle2 = tokio::task::spawn_blocking({
-        let tracked_path = tracked_path.clone();
-        move || {
-            item.blocking_persist(&tracked_path);
-            item
-        }
-    }); // Use same tracked_path
-    let item = persist_handle2.await.unwrap();
+    let persist_handle2 = arc.spawn_persist(&tracked_path); // Use same tracked_path
+    persist_handle2.await.unwrap();
     // --- Verification ---
     // store: 1 (No new store call needed)
     // persist: 1 (NO-OP: Already persisted at the target path) <--- CHANGE HERE
@@ -553,7 +535,7 @@ async fn test_persist_triggers_store_if_not_written_noop_if_done() {
     assert_eq!(setup.calls.persist.load(Ordering::SeqCst), 1); // Count remains 1
 
     // --- Action: Drop Arc ---
-    drop(item);
+    drop(arc);
     wait_for_store(&setup.backing_store).await;
     // --- Verification ---
     // delete: 1 (Item was written to temp store)
@@ -605,8 +587,8 @@ async fn test_persist_is_noop_if_already_persisted() {
     assert_eq!(setup.calls.all_persisted_keys.load(Ordering::SeqCst), 1);
 
     // --- Action: Register the Arc ---
-    let maybe_item = setup.pool.register(&tracked_path, key).await;
-    let item = maybe_item.unwrap();
+    let maybe_arc = setup.pool.register(&tracked_path, key).await;
+    let arc = maybe_arc.unwrap();
     // Reset calls after setup phase
     setup.calls.store.store(0, Ordering::SeqCst);
     setup.calls.persist.store(0, Ordering::SeqCst);
@@ -614,14 +596,8 @@ async fn test_persist_is_noop_if_already_persisted() {
     setup.calls.register.store(0, Ordering::SeqCst); // Reset this too
 
     // --- Action: Persist (item is already known persisted at this path) ---
-    let persist_handle = tokio::task::spawn_blocking({
-        let tracked_path = tracked_path.clone();
-        move || {
-            item.blocking_persist(&tracked_path);
-            item
-        }
-    });
-    let item = persist_handle.await.unwrap();
+    let persist_handle = arc.spawn_persist(&tracked_path);
+    persist_handle.await.unwrap();
 
     // --- Verification ---
     // store: 0 (No-op)
@@ -630,14 +606,14 @@ async fn test_persist_is_noop_if_already_persisted() {
     assert_eq!(setup.calls.persist.load(Ordering::SeqCst), 0);
 
     // --- Action: Load (just to double check item is valid) ---
-    let guard = item.load().await;
+    let guard = arc.load().await;
     assert_eq!(*guard, data);
     drop(guard);
     // load: 1 (First load triggers Strategy::load because register doesn't load)
     assert_eq!(setup.calls.load.load(Ordering::SeqCst), 1);
 
     // --- Action: Drop Arc ---
-    drop(item);
+    drop(arc);
     wait_for_store(&setup.backing_store).await;
     // --- Verification ---
     // delete: 1 (Mock register simulates adding to temp store)
@@ -663,15 +639,12 @@ async fn test_try_load_mut_unique_deletes_original_temp() {
         content: "mutate_unique_del".to_string(),
     };
 
-    let item = setup.pool.insert(data.clone());
+    let mut item = setup.pool.insert(data.clone());
     let original_key = item.key();
 
     // --- Action: Write original to temp store ---
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item.blocking_write_now();
-        item
-    });
-    let mut item = write_handle.await.unwrap();
+    let write_handle = item.spawn_write_now();
+    write_handle.await.unwrap();
     // store: 1, delete: 0
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
     assert!(setup.store_impl.get_temp_keys().contains(&original_key));
@@ -749,18 +722,13 @@ async fn test_make_mut_shared_clones_no_delete_during_call() {
         content: "make_mut_shared_clone".to_string(),
     };
 
-    let arc1 = Arc::new(setup.pool.insert(data.clone()));
+    let mut arc1 = Arc::new(setup.pool.insert(data.clone()));
     let arc2 = arc1.clone(); // Shared reference
     let original_key = arc1.key();
 
     // --- Action: Write original ---
-    let write_handle = tokio::task::spawn_blocking({
-        move || {
-            arc1.blocking_write_now();
-            arc1
-        }
-    });
-    let mut arc1 = write_handle.await.unwrap();
+    let write_handle = arc1.spawn_write_now();
+    write_handle.await.unwrap();
     // store: 1, delete: 0
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
     assert_eq!(setup.calls.delete.load(Ordering::SeqCst), 0);
@@ -1130,13 +1098,10 @@ async fn test_try_load_mut_triggers_load_if_not_cached() {
     };
 
     // --- Action: Insert A, Write A ---
-    let item_a = setup.pool.insert(data_a.clone());
+    let mut item_a = setup.pool.insert(data_a.clone());
     let original_key_a = item_a.key();
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item_a.blocking_write_now();
-        item_a
-    });
-    let mut item_a = write_handle.await.unwrap(); // A is now in temp store
+    let write_handle = item_a.spawn_write_now();
+    write_handle.await.unwrap(); // A is now in temp store
     // store: 1, load: 0, delete: 0
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
     assert_eq!(setup.calls.load.load(Ordering::SeqCst), 0);
@@ -2028,15 +1993,12 @@ async fn test_load_triggers_blocking_load_if_not_cached() {
     };
 
     // --- Setup: Insert A, write A, evict A ---
-    let item_a = setup.pool.insert(data_a.clone());
-    let key_a = item_a.key();
+    let arc_a = setup.pool.insert(data_a.clone());
+    let key_a = arc_a.key();
 
     // Write A to temp store so it's loadable after eviction
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item_a.blocking_write_now();
-        item_a
-    }); // Use async version for setup convenience
-    let item_a = write_handle.await.unwrap();
+    let write_handle = arc_a.spawn_write_now(); // Use async version for setup convenience
+    write_handle.await.unwrap();
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1); // A stored
     assert!(setup.store_impl.get_temp_keys().contains(&key_a));
     assert_eq!(setup.calls.load.load(Ordering::SeqCst), 0); // No loads yet
@@ -2049,7 +2011,7 @@ async fn test_load_triggers_blocking_load_if_not_cached() {
     // This call will use block_in_place internally because A is not cached.
     // It should block the current async test thread temporarily but succeed
     // because we specified the multi_thread runtime flavor.
-    let guard_a = item_a.load_in_place(); // THE CALL BEING TESTED
+    let guard_a = arc_a.load_in_place(); // THE CALL BEING TESTED
 
     // --- Verification ---
     assert_eq!(*guard_a, data_a); // Verify data is correct
@@ -2058,7 +2020,7 @@ async fn test_load_triggers_blocking_load_if_not_cached() {
 
     // --- Cleanup ---
     drop(guard_a);
-    drop(item_a);
+    drop(arc_a);
     // arc_b drops implicitly
     wait_for_store(&setup.backing_store).await;
     assert!(setup.calls.delete.load(Ordering::SeqCst) >= 1); // A should be deleted
@@ -2138,11 +2100,8 @@ async fn test_try_load_fails_when_not_cached() {
     // --- Setup: Insert A, write A, evict A ---
     let item_a = setup.pool.insert(data_a.clone());
     // Write A to temp store so it *could* be loaded, but won't be by try_load
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item_a.blocking_write_now();
-        item_a
-    });
-    let item_a = write_handle.await.unwrap();
+    let write_handle = item_a.spawn_write_now();
+    write_handle.await.unwrap();
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
 
     // Insert B to evict A
@@ -2175,14 +2134,11 @@ async fn test_sync_try_load_mut_success_when_cached() {
     };
 
     // --- Setup: Insert A, write A. A is cached and unique. ---
-    let item_a = setup.pool.insert(data_a.clone());
+    let mut item_a = setup.pool.insert(data_a.clone());
     let original_key_a = item_a.key();
     // Write A so delete behavior can be verified
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item_a.blocking_write_now();
-        item_a
-    });
-    let mut item_a = write_handle.await.unwrap();
+    let write_handle = item_a.spawn_write_now();
+    write_handle.await.unwrap();
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
     assert!(setup.store_impl.get_temp_keys().contains(&original_key_a));
     assert_eq!(setup.calls.load.load(Ordering::SeqCst), 0); // No loads needed yet
@@ -2232,13 +2188,10 @@ async fn test_sync_try_load_mut_fails_when_not_cached() {
     };
 
     // --- Setup: Insert A, write A, evict A ---
-    let item_a = setup.pool.insert(data_a.clone());
+    let mut item_a = setup.pool.insert(data_a.clone());
     let original_key_a = item_a.key();
-    let write_handle = tokio::task::spawn_blocking(move || {
-        item_a.blocking_write_now();
-        item_a
-    });
-    let mut item_a = write_handle.await.unwrap(); // A is in temp store
+    let write_handle = item_a.spawn_write_now();
+    write_handle.await.unwrap(); // A is in temp store
     let _arc_b = setup.pool.insert(data_b.clone()); // Evict A
     wait_for_store(&setup.backing_store).await;
     let initial_delete_count = setup.calls.delete.load(Ordering::SeqCst);
@@ -2423,16 +2376,11 @@ async fn test_async_make_mut_unique_no_clone() {
     };
 
     // --- Setup: Insert A, write A. A is cached and unique. ---
-    let arc_a = Arc::new(setup.pool.insert(data_a.clone()));
+    let mut arc_a = Arc::new(setup.pool.insert(data_a.clone()));
     let original_key_a = arc_a.key();
     // Write A so delete behavior can be verified
-    let write_handle = tokio::task::spawn_blocking({
-        move || {
-            arc_a.blocking_write_now();
-            arc_a
-        }
-    });
-    let mut arc_a = write_handle.await.unwrap();
+    let write_handle = arc_a.spawn_write_now();
+    write_handle.await.unwrap();
     assert_eq!(setup.calls.store.load(Ordering::SeqCst), 1);
     assert!(setup.store_impl.get_temp_keys().contains(&original_key_a));
     assert_eq!(Arc::strong_count(&arc_a), 1); // Verify unique


### PR DESCRIPTION
We can grab _all_ the guards before entering a blocking thread

This feels the most appropriate since it avoids ever using a blocking thread just to wait for a lock