### PR TITLE
skip copy to tmp and no-op hardlink on unchanged tiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ walkdir = { version = "2.5.0", optional = true }
 bincode = { version = "2.0.1", features = ["serde"], optional = true }
 serde = { version = "1.0.219", optional = true }
 
-prost = { version = ">= 0.13, <= 0.14", optional = true }
+prost = { version = "0.14", optional = true }
 
 [features]
 fbstore = ["dep:anyhow", "dep:nix", "dep:walkdir", "tokio/fs"]

--- a/src/backing_store.rs
+++ b/src/backing_store.rs
@@ -133,6 +133,11 @@ impl<P> TrackedPath<P> {
     pub fn all_keys(&self) -> Vec<Uuid> {
         self.present.iter().map(|entry| *entry.key()).collect()
     }
+
+    /// Returns `true` if the key is known to be persisted at this path.
+    pub fn contains_key(&self, key: Uuid) -> bool {
+        self.present.contains_key(&key)
+    }
 }
 
 impl<B: BackingStoreT> Drop for Token<B> {

--- a/src/convenience.rs
+++ b/src/convenience.rs
@@ -211,6 +211,12 @@ impl<B: BackingStoreT> Persister<B> {
     where
         B: Strategy<T>,
     {
+        let key = arc.key();
+        self.new_keys_set.insert(key);
+        // Already persisted at this path — skip the tmp write and no-op hard-link.
+        if self.tracked.contains_key(key) {
+            return;
+        }
         assert!(self.join_set.len() <= self.max_simultaneous_tasks);
         if self.join_set.len() == self.max_simultaneous_tasks {
             self.runtime
@@ -219,7 +225,6 @@ impl<B: BackingStoreT> Persister<B> {
                 .unwrap();
         }
         let tracked = Arc::clone(&self.tracked);
-        self.new_keys_set.insert(arc.key());
         let arc = Arc::clone(arc);
         self.join_set.spawn_on(
             async move { arc.spawn_persist(&tracked).await.await.unwrap() },


### PR DESCRIPTION
## Description
Skip redundant tmp writes for tiles already persisted at the target path during `prepare_save`


## Testing
 All 40 existing tests pass, including `test_blocking_save_skips_already_persisted` and `test_persist_is_noop_if_already_persisted`